### PR TITLE
fix: remediate Dependabot alert for brace-expansion

### DIFF
--- a/mainsite-frontend/package-lock.json
+++ b/mainsite-frontend/package-lock.json
@@ -1323,9 +1323,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- refreshes mainsite-frontend lockfile via npm audit fix
- updates transitive brace-expansion to patched versions
- keeps source code unchanged

## Validation
- npm audit fix (0 vulnerabilities)
- npm ls brace-expansion shows patched versions
- npm run build succeeds