### PR TITLE
chore(repo): finalize organization migration metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -26,8 +24,6 @@ updates:
       - "dependencies"
       - "npm"
       - "frontend"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -91,8 +87,6 @@ updates:
       - "dependencies"
       - "npm"
       - "worker"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            exit 0
+          fi
+          gh pr merge "$PR_URL" --auto --merge

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You will need:
 ### 1. Clone + install
 
 ```bash
-git clone https://github.com/lcv-leo/mainsite-app.git
+git clone https://github.com/LCV-Ideas-Software/mainsite-app.git
 cd mainsite-app
 cd mainsite-frontend && npm ci && cd ..
 cd mainsite-worker && npm ci && cd ..

--- a/mainsite-frontend/CHANGELOG.md
+++ b/mainsite-frontend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — Mainsite Frontend
 
+## [v03.21.07] - 2026-04-27
+### Alterado — migração GitHub org + Pages/Sponsors custom domain
+- Repositório transferido para `LCV-Ideas-Software/mainsite-app`; README e rodapé de compliance apontam para o repositório público da organização.
+- `.github/FUNDING.yml` preserva o link custom `https://mainsite-app.lcv.app.br/` para o botão Sponsor, com `github: lcv-leo`.
+- Dependabot deixa de atribuir PRs ao usuário e ganha workflow `Dependabot Automerge` restrito a `dependabot[bot]`, sem checkout de código de PR.
+### Validação
+- `npm run lint`.
+- `npm run build`.
+- YAML dos workflows/dependabot parseado via `js-yaml`.
+- Pages custom domain `https://mainsite-app.lcv.app.br/` respondeu HTTP 200.
+
 ## [v03.21.00] - 2026-04-25
 ### Segurança
 - Adicionado helper de publicação para Pages Functions (`functions/_lib/publishing.ts`) que lê `mainsite/publishing`, respeita modo `hidden` e filtra `is_published=1` antes de expor posts públicos.

--- a/mainsite-frontend/src/App.tsx
+++ b/mainsite-frontend/src/App.tsx
@@ -40,7 +40,7 @@ const ChatWidget = lazy(() => import('./components/ChatWidget'));
 const DonationModal = lazy(() => import('./components/DonationModal'));
 
 const API_URL = '/api';
-const APP_VERSION = 'APP v03.21.06';
+const APP_VERSION = 'APP v03.21.07';
 const SITE_NAME = 'Reflexos da Alma';
 const SITE_URL = 'https://www.reflexosdaalma.blog';
 const ABOUT_PATH = '/sobre-este-site';

--- a/mainsite-frontend/src/components/ComplianceBanner.tsx
+++ b/mainsite-frontend/src/components/ComplianceBanner.tsx
@@ -48,7 +48,12 @@ export const ComplianceBanner: React.FC<ComplianceBannerProps> = ({ onViewLicens
         Licenças (GNU AGPLv3 + Apache 2.0)
       </a>
       <span aria-hidden="true">|</span>
-      <a href="https://github.com/lcv-leo/mainsite-app" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+      <a
+        href="https://github.com/LCV-Ideas-Software/mainsite-app"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={linkStyle}
+      >
         Código Fonte (GitHub)
       </a>
     </footer>


### PR DESCRIPTION
## Summary
- finalize repository metadata after transfer to LCV-Ideas-Software
- keep compliance footer pointing to public GitHub source and Sponsors button pointing to the custom Pages domain through FUNDING.yml
- remove personal Dependabot assignees and add Dependabot-only auto-merge workflow
- bump app version to APP v03.21.07 and document validation in CHANGELOG

## Validation
- npm run lint
- npm run build
- npx --yes js-yaml .github/dependabot.yml
- npx --yes js-yaml .github/workflows/dependabot-automerge.yml
- GitHub Pages API checked custom domain HTTPS approval/enforcement

Note: cross-review-mcp is temporarily paused because long rounds are being diagnosed separately.