### PR TITLE
[codex] Fix nested dependency vulnerabilities

### DIFF
--- a/mainsite-frontend/package-lock.json
+++ b/mainsite-frontend/package-lock.json
@@ -4455,9 +4455,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9974,9 +9974,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/mainsite-frontend/package.json
+++ b/mainsite-frontend/package.json
@@ -66,6 +66,7 @@
     "undici": "6.24.0",
     "vite": "$vite",
     "serialize-javascript": "^7.0.5",
+    "ws": "8.20.1",
     "workbox-build": {
       "glob": "13.0.6"
     },


### PR DESCRIPTION
## Summary
- Clear remaining Scorecard VulnerabilitiesID findings in nested npm projects
- Patch vulnerable ws/brace-expansion transitive versions in subproject lockfiles
- Keep workflow action pins unchanged after confirming all actions are current

## Validation
- npm audit in affected subproject
- npm run biome in affected subproject where available
- npm test in affected subproject
- verified workflow Actions are already on latest published tags before commit