### PR TITLE
ci: reintroduce Socket security workflow

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,71 @@
+name: Socket Security
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: socket-scan-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  socket-security:
+    name: Socket Security
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Socket CLI
+        run: pip install socketsecurity --upgrade
+
+      - name: Validate Socket API key
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+        run: |
+          if [ -z "$SOCKET_SECURITY_API_KEY" ]; then
+            echo "::error::SOCKET_SECURITY_API_KEY is not configured for this repository or organization."
+            exit 1
+          fi
+
+      - name: Run Socket Security Scan (audit)
+        continue-on-error: true
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=0
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+          fi
+
+          socketcli \
+            --target-path "$GITHUB_WORKSPACE" \
+            --scm github \
+            --pr-number "$PR_NUMBER"


### PR DESCRIPTION
## Summary

- reintroduces the official Socket Security GitHub Actions workflow
- keeps Socket in audit/observation mode: scan findings do not fail the job (`continue-on-error: true`)
- keeps configuration failures blocking: missing `SOCKET_SECURITY_API_KEY` fails early
- runs StepSecurity Harden-Runner in audit mode before the Socket scan

## Notes

- `SOCKET_SECURITY_API_KEY` is configured as an Actions secret for this repository.
- The main ruleset requires the `Socket Security` check, so this PR must go through the PR gate instead of direct main push.
- References: https://docs.socket.dev/docs/socket-for-github-actions and https://docs.socket.dev/docs/socket-yml