### PR TITLE
[codex] fix frontend jsdom undici override

### DIFF
--- a/mainsite-frontend/package-lock.json
+++ b/mainsite-frontend/package-lock.json
@@ -9541,13 +9541,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/mainsite-frontend/package.json
+++ b/mainsite-frontend/package.json
@@ -64,7 +64,6 @@
   },
   "overrides": {
     "picomatch": "4.0.4",
-    "undici": "6.24.0",
     "vite": "$vite",
     "serialize-javascript": "^7.0.5",
     "ws": "8.20.1",


### PR DESCRIPTION
## Summary

- Removes the stale `mainsite-frontend` `overrides.undici = 6.24.0` pin.
- Regenerates the frontend lockfile so `jsdom@29.1.1` resolves its compatible `undici@7.27.1` dependency.

## Root Cause

Deploy #612 failed in the frontend `npm test` gate before build/deploy. `jsdom@29.1.1` requires `undici ^7.25.0`, but the frontend package override forced `undici@6.24.0` across the tree. Vitest could not start jsdom workers because `undici/lib/handler/wrap-handler.js` is absent from the forced 6.x package.

The final `1df2f16` CodeQL bump only surfaced the broken head; the dependency conflict was introduced earlier by the `jsdom` bump.

## Validation

Frontend:

- `npm ci`
- `npm audit --audit-level=high --registry=https://registry.npmjs.org/`
- `npm run lint`
- `npm run biome` (exit 0; existing schema-version info remains)
- `npm test` (4 files, 22 tests passed)
- `npm run build`

Worker local gate, because Deploy runs it before frontend:

- `npm ci` (exit 0; existing package/script warnings only)
- `npm audit --audit-level=high --registry=https://registry.npmjs.org/`
- `npm run lint`
- `npm run biome` (exit 0; existing optional-chain warning/schema info remains)
- `npm test` (9 files, 23 tests passed)

`wrangler deploy` / `wrangler pages deploy` were not run locally because they require Cloudflare deployment credentials and would mutate production state.