### PR TITLE
Fix release notes for paired versions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,7 +96,7 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             for pattern in "APP v$RAW_VERSION" "v$RAW_VERSION" "v$STRIPPED" "$RAW_VERSION" "$STRIPPED"; do
               CANDIDATE=$(awk -v ver="$pattern" '
-                $0 ~ "^## \\[" ver "\\]" { found=1; next }
+                index($0, "## [" ver "]") == 1 || index($0, "## [" ver " /") == 1 { found=1; next }
                 found && /^## \[/ { exit }
                 found { print }
               ' CHANGELOG.md 2>/dev/null || true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Corrigido — automação de release
+
+- O extrator de notas agora reconhece headings combinados de frontend e worker, evitando releases com descrição genérica quando o changelog usa o formato `## [vFrontend / vWorker]`.
+
 ## [v03.23.04 / v02.19.04] - 2026-07-21
 
 ### Segurança


### PR DESCRIPTION
## Root cause

The auto-release workflow matched only exact headings such as `## [v03.23.04]`. The current changelog uses paired frontend/worker headings such as `## [v03.23.04 / v02.19.04]`, so release-note extraction fell back to the generic message.

## Change

- Accept exact single-version headings and paired headings whose first version matches.
- Document the workflow correction under `Unreleased`.
- Restore the full public body for `v03.23.04` (already applied and independently verified).

## Verification

- Pre-fix reproduction: all five version candidates extracted zero bytes.
- Exact updated GNU Awk program: paired heading exit 0, 981 chars / 990 UTF-8 bytes.
- Single heading regression: exit 0, 1339 chars / 1352 UTF-8 bytes.
- Extracted paired notes equal the live `v03.23.04` body.
- `actionlint .github/workflows/auto-release.yml`
- `git diff --check`
- Root public formatting; worker lint/Biome/tests; frontend lint/Biome/tests/build.
- Cross-review session `a6417487-70c4-49f3-b793-b19460e9e104`: all five peers READY with no blocking objections.