### PR TITLE
chore: update Dependabot controller pin

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -34,7 +34,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@06078610da5edd1c6d020db205c69d3cd580fcf9
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@d8f67ca034edb6173ce9baaff41ccb320ef4bf2d
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Resumo

- atualiza exclusivamente o pin do controlador Dependabot para `d8f67ca034edb6173ce9baaff41ccb320ef4bf2d`;
- incorpora a correção central que reconhece os manifests canônicos `socketsecurity-requirements.in` e `socketsecurity-requirements.txt`;
- preserva `permissions: write-all` no workflow e no job.

## Causa

O pin anterior recusava esses dois manifests seguros pelo allowlist, impedindo auto-review, rebase do Dependabot e squash automático para atualizações GitPython.

## Validação

- YAML analisado com `yq`;
- workflow validado com Prettier;
- diff sem whitespace inválido;

O aviso local do actionlint sobre `concurrency.queue` é idêntico ao baseline de `main` e não foi introduzido por este diff.