### PR TITLE
fix(ci): harden Socket metadata and Dependabot automation

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -34,7 +34,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@d8f67ca034edb6173ce9baaff41ccb320ef4bf2d
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@3f62b39a76f767d09a5482b8e380746883be3b94
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -55,8 +55,10 @@ jobs:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOCKET_PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
+          SOCKET_SCAN_COMMIT_MESSAGE: ${{ github.sha }}
         run: |
           socketcli \
             --target-path "$GITHUB_WORKSPACE" \
             --scm github \
+            --commit-message "$SOCKET_SCAN_COMMIT_MESSAGE" \
             --pr-number "$SOCKET_PR_NUMBER"

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -55,10 +55,12 @@ jobs:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOCKET_PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
-          SOCKET_SCAN_COMMIT_MESSAGE: ${{ github.sha }}
+          SOCKET_SCAN_COMMIT_SHA: ${{ github.sha }}
         run: |
+          SOCKET_SCAN_COMMIT_MESSAGE="$(git show -s --format=%s "$SOCKET_SCAN_COMMIT_SHA")"
           socketcli \
             --target-path "$GITHUB_WORKSPACE" \
             --scm github \
-            --commit-message "$SOCKET_SCAN_COMMIT_MESSAGE" \
+            --commit-sha "$SOCKET_SCAN_COMMIT_SHA" \
+            --commit-message="$SOCKET_SCAN_COMMIT_MESSAGE" \
             --pr-number "$SOCKET_PR_NUMBER"


### PR DESCRIPTION
Passes an explicit commit SHA and bounded subject to Socket CLI, and pins the hardened central Dependabot controller. Adversarial argparse reproduction and zizmor passed.