### PR TITLE
fix(ci): harden release convergence and dependency audits

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -627,6 +627,14 @@ jobs:
               jq -sc 'if length == 0 then [] else add end'
           }
 
+          published_release_snapshot() {
+            local encoded_tag
+            encoded_tag="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" |
+              jq -c '[.]'
+          }
+
           resolve_commitish() {
             local commitish="$1"
             local encoded_commitish resolved_sha
@@ -758,13 +766,41 @@ jobs:
           esac
 
           assert_tag_is_target "$RELEASE_TAG"
-          releases="$(release_snapshot)"
-          selected_releases="$(jq -c --arg tag "$RELEASE_TAG" '[.[] | select(.tag_name == $tag)]' <<<"$releases")"
-          final_state="$(release_state "$selected_releases")"
-          if [ "$final_state" != published ]; then
-            echo "::error::Release ${RELEASE_TAG} did not converge to a published normal release." >&2
-            exit 1
-          fi
+          # A successful release mutation can precede visibility through the
+          # read endpoint. Retry only GET visibility; release_state still fails
+          # immediately for an invalid target, prerelease, or uploaded asset.
+          final_state=unavailable
+          lookup_error=
+          for retry_delay in 1 2 4 8 15 0; do
+            if selected_releases="$(published_release_snapshot 2>&1)"; then
+              final_state="$(release_state "$selected_releases")"
+              case "$final_state" in
+                published)
+                  break
+                  ;;
+                missing | draft) ;;
+                *)
+                  echo "::error::Unexpected release convergence state: ${final_state}." >&2
+                  exit 1
+                  ;;
+              esac
+            else
+              lookup_error="$selected_releases"
+              final_state=unavailable
+            fi
+            if [ "$retry_delay" -eq 0 ]; then
+              echo "::error::Release ${RELEASE_TAG} did not converge to a published normal release after bounded retries (last state: ${final_state})." >&2
+              exit 1
+            fi
+            if [ "$final_state" = unavailable ]; then
+              echo "Published release lookup has not succeeded yet: ${lookup_error}" >&2
+            else
+              echo "Release ${RELEASE_TAG} has not converged to published (state=${final_state})."
+            fi
+            echo "Retrying release verification in ${retry_delay}s."
+            sleep "$retry_delay"
+          done
+          assert_tag_is_target "$RELEASE_TAG"
           assert_target_is_on_main "after release publication"
           echo "Verified published release ${RELEASE_TAG} at ${TARGET_SHA} with no uploaded assets."
     timeout-minutes: 60

--- a/mainsite-frontend/package-lock.json
+++ b/mainsite-frontend/package-lock.json
@@ -4784,16 +4784,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -5883,43 +5883,16 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-2.0.2.tgz",
+      "integrity": "sha512-qiTS+zFS40hGcaPnunc1VBkcaiEBdMSughI6Jfm5ojSNUnn28vpfftIm/q7SIjLf6Ws+l8DMWlnzlZV/f8GKAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/find-up": {

--- a/mainsite-frontend/package.json
+++ b/mainsite-frontend/package.json
@@ -64,11 +64,9 @@
   },
   "overrides": {
     "minimatch@^10.0.0": {
-      "brace-expansion": "5.0.7"
+      "brace-expansion": "5.0.8"
     },
-    "minimatch@^5.0.0": {
-      "brace-expansion": "2.1.2"
-    },
+    "filelist": "2.0.2",
     "picomatch": "4.0.4",
     "vite": "$vite",
     "serialize-javascript": "^7.0.5",

--- a/mainsite-worker/package-lock.json
+++ b/mainsite-worker/package-lock.json
@@ -2605,16 +2605,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -3863,9 +3863,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4059,9 +4059,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4078,7 +4078,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/mainsite-worker/package.json
+++ b/mainsite-worker/package.json
@@ -39,9 +39,10 @@
   },
   "overrides": {
     "minimatch@^10.0.0": {
-      "brace-expansion": "5.0.7"
+      "brace-expansion": "5.0.8"
     },
     "picomatch": "4.0.4",
+    "postcss": "8.5.23",
     "undici": "6.27.0",
     "vite": "8.0.16",
     "ws": "8.21.0",


### PR DESCRIPTION
## O que mudou

- A verificação pós-publicação consulta a release publicada diretamente pela tag e repete somente leituras GET com backoff limitado (máximo de 30 segundos).
- O worker atualiza `brace-expansion` para `5.0.8` e `postcss` para a latest `8.5.23`; o lockfile incorpora `nanoid 3.3.16` exigido pelo PostCSS atual.
- O frontend substitui `filelist 1.0.6` por `2.0.2`, que mantém a API e migra de `minimatch 5` para `10`, permitindo `brace-expansion 5.0.8` sem forçar uma dependência incompatível. `vite-plugin-pwa 1.3.0` permanece na latest.

## Causas raiz

1. Um `gh release create` retornou sucesso, mas a leitura agregada feita menos de um segundo depois ainda não enxergou a release: corrida de consistência de leitura.
2. O check remoto expôs dois advisories high publicados em 24/07/2026: `brace-expansion <=5.0.7` e `postcss <=8.5.17`. O primeiro estava explicitamente sobrescrito para a versão vulnerável no worker e no frontend; o segundo permanecia transitivo no lockfile do worker.

## Segurança e impacto

- não repete criação, edição ou exclusão de release;
- preserva validações de prerelease, assets, target SHA e ancestralidade em `main`;
- falha fechada se a release não convergir;
- usa as versões seguras mais novas publicadas no npm;
- evita o downgrade para `vite-plugin-pwa 1.2.0` sugerido por `npm audit --force`;
- não altera código de aplicação, banco de dados ou deploy.

## Validação

- reprodução limpa dos baselines worker e frontend: `npm audit --audit-level=high` falhou com os GHSAs;
- worker após a correção: `npm ci`, `npm audit` (0 vulnerabilidades), ESLint, Biome e Vitest (9 arquivos/23 testes) verdes;
- frontend após a correção: `npm ci`, `npm audit` (0 vulnerabilidades), árvore npm íntegra, ESLint, Biome, Vitest (4 arquivos/22 testes), build Vite e geração PWA verdes;
- testes comportamentais do fragmento shell literal;
- ShellCheck 0.11.0, actionlint 1.7.12, `git diff --check`;
- zizmor 1.28.0 em modo auditor: zero achados;
- revisão independente Ultrabrain + cross-review antes da mesclagem.

Referências oficiais:
- https://docs.github.com/en/rest/releases/releases#get-a-release-by-tag-name
- https://github.com/advisories/GHSA-mh99-v99m-4gvg
- https://github.com/advisories/GHSA-r28c-9q8g-f849
- https://github.com/mde/filelist/compare/v1.0.6...v2.0.2