### PR TITLE
chore(ai): remove o binding legado GEMINI_API_KEY — worker v02.20.01

### DIFF
--- a/mainsite-worker/CHANGELOG.md
+++ b/mainsite-worker/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [v02.20.01] - 2026-08-10
+
+### Removido
+
+- **Binding legado `GEMINI_API_KEY`.** A v02.20.00 manteve o binding "até o
+  descomissionamento coordenado da frota"; esse momento chegou. Saem o binding
+  do `wrangler.json`, as duas declarações em `env.ts` (`SecretStoreBinding` e a
+  forma resolvida), a entrada em `SECRET_KEYS` do resolver e o campo opcional em
+  `EnvSecretsSchema`. Nenhum handler lia a chave desde a migração — a varredura
+  do repositório não encontra leitura alguma, apenas as declarações.
+
+### Corrigido
+
+- `APP_VERSION` estava em `v02.19.05` enquanto o CHANGELOG já registrava a
+  v02.20.00 da migração Vertex; a constante volta a acompanhar a versão.
+
 ## [v02.20.00] - 2026-08-08
 
 ### Alterado

--- a/mainsite-worker/package-lock.json
+++ b/mainsite-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mainsite-worker",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mainsite-worker",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "@types/sanitize-html": "^2.16.1",

--- a/mainsite-worker/package.json
+++ b/mainsite-worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mainsite-worker",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/mainsite-worker/src/env.ts
+++ b/mainsite-worker/src/env.ts
@@ -37,7 +37,6 @@ export interface RawEnv {
 
   // --- Secrets & Tokens (Secret Store → .get()) ---
   CLOUDFLARE_PW: SecretStoreBinding;
-  GEMINI_API_KEY: SecretStoreBinding;
   RESEND_API_KEY: SecretStoreBinding;
 
   // --- Vertex AI (Gemini Enterprise Agent Platform) ---
@@ -86,7 +85,6 @@ export interface Env {
 
   // --- Secrets & Tokens (resolved to string by middleware) ---
   CLOUDFLARE_PW: string;
-  GEMINI_API_KEY: string;
   RESEND_API_KEY: string;
 
   // --- Vertex AI (resolved to string by middleware) ---

--- a/mainsite-worker/src/index.ts
+++ b/mainsite-worker/src/index.ts
@@ -7,7 +7,7 @@
  * Hono-based modular Worker com paridade total ao monolito.
  * Versão modular: todos os domínios em src/routes/*.ts
  */
-export const APP_VERSION = 'APP v02.19.05';
+export const APP_VERSION = 'APP v02.20.01';
 
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
@@ -47,10 +47,9 @@ app.use(
 // ========== SECRET STORE RESOLVER MIDDLEWARE ==========
 // Cloudflare Secret Store bindings are Fetcher objects with `.get()`.
 // This middleware eagerly resolves all secret values so downstream
-// handlers can use c.env.GEMINI_API_KEY as a plain string.
+// handlers can use c.env.VERTEX_SA_KEY as a plain string.
 const SECRET_KEYS = [
   'CLOUDFLARE_PW',
-  'GEMINI_API_KEY',
   'VERTEX_SA_KEY',
   'RESEND_API_KEY',
   'GCP_NL_API_KEY',

--- a/mainsite-worker/src/lib/schemas.ts
+++ b/mainsite-worker/src/lib/schemas.ts
@@ -112,8 +112,6 @@ export const EnvSecretsSchema = z.object({
   CLOUDFLARE_PW: z.string().min(1),
   // Credencial Vertex AI (SA JSON) — transporte atual da IA.
   VERTEX_SA_KEY: z.string().min(1),
-  // Legado AI Studio: binding permanece até o descomissionamento coordenado.
-  GEMINI_API_KEY: z.string().min(1).optional(),
   RESEND_API_KEY: z.string().min(1),
   // Feature-gated (handlers retornam 503 quando faltam): require para alinhar schema/runtime
   GCP_NL_API_KEY: z.string().min(1),

--- a/mainsite-worker/wrangler.json
+++ b/mainsite-worker/wrangler.json
@@ -81,11 +81,6 @@
       "secret_name": "cloudflare-pw"
     },
     {
-      "binding": "GEMINI_API_KEY",
-      "store_id": "df90c0935ba1460899c3c2c457548a90",
-      "secret_name": "gemini-api-key"
-    },
-    {
       "binding": "VERTEX_SA_KEY",
       "store_id": "df90c0935ba1460899c3c2c457548a90",
       "secret_name": "vertex-sa-key"


### PR DESCRIPTION
> **Draft de propósito** — o merge é automático quando os checks fecham. Fica em draft até a rodada de bots assentar.

A v02.20.00 (migração para Vertex AI) deixou escrito no próprio CHANGELOG que o binding legado permaneceria "até o descomissionamento coordenado da frota". Este PR faz a parte do `mainsite-worker`.

## Por que é seguro

Nenhum handler lê a chave desde a migração. A varredura do repositório encontra apenas **declarações**, nunca leitura:

```
mainsite-worker/src/env.ts:40      GEMINI_API_KEY: SecretStoreBinding;   (declaração)
mainsite-worker/src/env.ts:89      GEMINI_API_KEY: string;               (declaração)
mainsite-worker/src/index.ts:53    'GEMINI_API_KEY',                     (lista do resolver)
mainsite-worker/src/lib/schemas.ts:116  GEMINI_API_KEY: ...optional()    (schema)
mainsite-worker/wrangler.json:84   binding                               (declaração)
```

Todo o consumo de IA passa por `lib/vertex.ts` com `VERTEX_SA_KEY`, e a produção comprova: uma chamada real ao `/api/ai/public/chat` respondeu HTTP 200 com texto do modelo durante a investigação desta madrugada.

## O que sai

Binding do `wrangler.json`, as duas declarações de `env.ts`, a entrada em `SECRET_KEYS` do resolver e o campo opcional em `EnvSecretsSchema`.

## Ordem do descomissionamento

O secret `gemini-api-key` **permanece** no Secrets Store por enquanto. Um binding apontando para secret inexistente quebra o deploy, então a ordem obrigatória é: publicar todos os workers sem o binding e só depois apagar o secret. O `admin-motor` ainda o declara (PR em preparação); quando os dois estiverem em produção, o secret pode sair.

## Correção adicional

`APP_VERSION` estava em `v02.19.05` enquanto o CHANGELOG do worker já registrava a `v02.20.00` — a constante volta a acompanhar a versão, agora `v02.20.01`.

## Drift pré-existente que NÃO toquei

`CHANGELOG.md`, `README.md` e `SECURITY.md` da raiz ainda anunciam `mainsite-worker v02.19.04/05` e não registram a v02.20.00 da migração. É anterior a este PR e envolve o par frontend/worker; prefiro tratá-lo num PR de documentação em vez de misturar aqui.

## Verificação

`types`, `lint`, `biome` e `test` (10 arquivos / 41 testes) — todos exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)