### PR TITLE
fix(deps): pin unbash for License Compliance (MAISITE-7)

### DIFF
--- a/mainsite-frontend/package-lock.json
+++ b/mainsite-frontend/package-lock.json
@@ -36,7 +36,7 @@
         "globals": "^17.9.0",
         "husky": "^9.1.7",
         "jsdom": "^30.0.1",
-        "knip": "^6.32.1",
+        "knip": "^6.32.2",
         "lint-staged": "^17.3.0",
         "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "~6.0.3",
@@ -3493,9 +3493,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.142.0.tgz",
-      "integrity": "sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+      "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
       "cpu": [
         "arm"
       ],
@@ -3510,9 +3510,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.142.0.tgz",
-      "integrity": "sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+      "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
       "cpu": [
         "arm64"
       ],
@@ -3527,9 +3527,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.142.0.tgz",
-      "integrity": "sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+      "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
       "cpu": [
         "arm64"
       ],
@@ -3544,9 +3544,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.142.0.tgz",
-      "integrity": "sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+      "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
       "cpu": [
         "x64"
       ],
@@ -3561,9 +3561,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.142.0.tgz",
-      "integrity": "sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+      "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
       "cpu": [
         "x64"
       ],
@@ -3578,9 +3578,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.142.0.tgz",
-      "integrity": "sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+      "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
       "cpu": [
         "arm"
       ],
@@ -3595,9 +3595,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.142.0.tgz",
-      "integrity": "sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+      "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
       "cpu": [
         "arm"
       ],
@@ -3612,9 +3612,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.142.0.tgz",
-      "integrity": "sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+      "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
       "cpu": [
         "arm64"
       ],
@@ -3632,9 +3632,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.142.0.tgz",
-      "integrity": "sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+      "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
       "cpu": [
         "arm64"
       ],
@@ -3652,9 +3652,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.142.0.tgz",
-      "integrity": "sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+      "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
       "cpu": [
         "ppc64"
       ],
@@ -3672,9 +3672,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.142.0.tgz",
-      "integrity": "sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+      "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
       "cpu": [
         "riscv64"
       ],
@@ -3692,9 +3692,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.142.0.tgz",
-      "integrity": "sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+      "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
       "cpu": [
         "riscv64"
       ],
@@ -3712,9 +3712,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.142.0.tgz",
-      "integrity": "sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+      "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
       "cpu": [
         "s390x"
       ],
@@ -3732,9 +3732,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.142.0.tgz",
-      "integrity": "sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+      "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
       "cpu": [
         "x64"
       ],
@@ -3752,9 +3752,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.142.0.tgz",
-      "integrity": "sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+      "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
       "cpu": [
         "x64"
       ],
@@ -3772,9 +3772,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.142.0.tgz",
-      "integrity": "sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+      "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
       "cpu": [
         "arm64"
       ],
@@ -3788,52 +3788,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.142.0.tgz",
-      "integrity": "sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.2",
-        "@emnapi/runtime": "1.11.2",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.142.0.tgz",
-      "integrity": "sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+      "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
       "cpu": [
         "arm64"
       ],
@@ -3848,9 +3806,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.142.0.tgz",
-      "integrity": "sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+      "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
       "cpu": [
         "ia32"
       ],
@@ -3865,9 +3823,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.142.0.tgz",
-      "integrity": "sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+      "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
       "cpu": [
         "x64"
       ],
@@ -8506,9 +8464,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.32.1",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.32.1.tgz",
-      "integrity": "sha512-mIiIHMTJVUgSlz0mxEgPt7wg8DmfbCp1Txqab3WpbMCJF7YHvHtC9jeAHHXfISMl72N8WzhyG71SQlaqCOGZtg==",
+      "version": "6.32.2",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.32.2.tgz",
+      "integrity": "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg==",
       "dev": true,
       "funding": [
         {
@@ -8526,13 +8484,13 @@
         "formatly": "^0.3.0",
         "get-tsconfig": "4.14.1",
         "jiti": "^2.7.0",
-        "oxc-parser": "^0.142.0",
+        "oxc-parser": "^0.143.0",
         "oxc-resolver": "11.24.2",
         "picomatch": "^4.0.5",
         "smol-toml": "^1.7.1",
         "strip-json-comments": "5.0.3",
         "tinyglobby": "^0.2.17",
-        "unbash": "^4.0.4",
+        "unbash": "^4.0.9",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
@@ -9212,13 +9170,13 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.142.0.tgz",
-      "integrity": "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+      "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.142.0"
+        "@oxc-project/types": "^0.143.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -9227,26 +9185,35 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.142.0",
-        "@oxc-parser/binding-android-arm64": "0.142.0",
-        "@oxc-parser/binding-darwin-arm64": "0.142.0",
-        "@oxc-parser/binding-darwin-x64": "0.142.0",
-        "@oxc-parser/binding-freebsd-x64": "0.142.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.142.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.142.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.142.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.142.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.142.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.142.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.142.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.142.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.142.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.142.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.142.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.143.0",
+        "@oxc-parser/binding-android-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-x64": "0.143.0",
+        "@oxc-parser/binding-freebsd-x64": "0.143.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.143.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.143.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/oxc-resolver": {
@@ -10787,9 +10754,9 @@
       }
     },
     "node_modules/unbash": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.5.tgz",
-      "integrity": "sha512-EE9xv9cr93DSppe086Rnbq0jwG7MBCEe22JZ4UQ8Bn9RyUwDSoUpBmzdb5+7PzocdqBEb/K73FGPaQUMmLxTQQ==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.10.tgz",
+      "integrity": "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==",
       "dev": true,
       "license": "ISC",
       "engines": {

--- a/mainsite-frontend/package-lock.json
+++ b/mainsite-frontend/package-lock.json
@@ -8502,6 +8502,16 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/knip/node_modules/unbash": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.9.tgz",
+      "integrity": "sha512-J8HTKzXbwi6oQKiKEbTKMsc30jKaU5vEzDejemz4bK8OqfENSPWWV8lW+Dl7rvcTTwBmAx/It4PUd1H9RjESIw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10751,16 +10761,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/unbash": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.10.tgz",
-      "integrity": "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/unbox-primitive": {

--- a/mainsite-frontend/package.json
+++ b/mainsite-frontend/package.json
@@ -47,7 +47,7 @@
     "globals": "^17.9.0",
     "husky": "^9.1.7",
     "jsdom": "^30.0.1",
-    "knip": "^6.32.1",
+    "knip": "^6.32.2",
     "lint-staged": "^17.3.0",
     "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "~6.0.3",

--- a/mainsite-frontend/package.json
+++ b/mainsite-frontend/package.json
@@ -69,6 +69,7 @@
     },
     "filelist": "2.0.2",
     "picomatch": "4.0.4",
+    "unbash": "4.0.9",
     "vite": "$vite",
     "serialize-javascript": "^7.0.5",
     "ws": "8.21.0",


### PR DESCRIPTION
## Resumo

- mantém o upgrade de `knip` para 6.32.2 no `mainsite-frontend`;
- fixa somente a dependência transitiva compatível `unbash` em 4.0.9;
- regenera o lockfile sem alterar a allowlist de licenças.

## Causa raiz e RED nativo

No head `b4633a77fc302d6b155a229cde7db3c6f13b1a48` do PR #443, o Dependency Graph nativo classificou `unbash@4.0.10` com `license: null`, embora o pacote declare ISC. O check `github-license-compliance` registrou **1 new license compliance alert** e o ruleset manteve a conversa bloqueante.

`knip@6.32.2` aceita `unbash ^4.0.9`; portanto, 4.0.9 é o menor pin compatível e também declara ISC no registry oficial.

## Validação local

- `npm ci` em frontend e worker: zero vulnerabilidades;
- formatação pública;
- worker: lint, Biome e 10/10 arquivos com 41/41 testes;
- frontend: lint, Biome, 4/4 arquivos com 22/22 testes e build;
- commit GPG assinado.

## Supersessão segura

Este draft substitui tecnicamente o PR #443, que permanece aberto e intocado até o scanner nativo confirmar zero alerta neste head exato. Só depois dessa prova deve-se fechar #443 como superseded; sua conversa não deve ser resolvida antecipadamente.

Fixes MAISITE-7
Closes #445

Linear: https://linear.app/lcv-ideas-software/issue/MAISITE-7/corrigir-bloqueio-nativo-de-license-compliance-do-knip-6322
PR original: https://github.com/LCV-Ideas-Software/mainsite-app/pull/443