### PR TITLE
fix(ci): run zizmor for merge groups

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 permissions: {}
 


### PR DESCRIPTION
## Resumo

- restaura o evento `merge_group.checks_requested` no workflow Zizmor;
- preserva o check obrigatório `Run zizmor`, as permissões, a concorrência e todos os pins;
- corrige o check ausente observado no SHA sintético da merge queue.

## Evidência

O attempt 2 do [Dependabot Custom Auto-merge #24](https://github.com/LCV-Ideas-Software/github-operations/actions/runs/32515667517) registrou `missing=Run zizmor` para o merge group de `mainsite-app#457`. O histórico mostra que o trigger havia sido removido na troca para a action oficial em 15/08/2026.

## Validação

- `actionlint` em todos os workflows;
- `gh actions-lock --no-fix`: `valid=true`;
- formato público: verde;
- worker: lint, Biome e 49/49 testes;
- frontend: lint, Biome, 28/28 testes e build;
- revisão independente: sem objeção técnica.

O PR não habilita auto-merge e deve atravessar a admissão humana e o `merge_group`, onde `Run zizmor` será a prova funcional do reparo.