### PR TITLE
ci: adotar action oficial de Linear Release

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -18,6 +18,7 @@ workflows:
         - 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020'
     '.github/workflows/linear-release.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+        - 'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205'
     '.github/workflows/pages.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d'
@@ -89,6 +90,11 @@ dependencies:
         commit: 'sha1-db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28'
         owner_id: 9919
         repo_id: 259445878
+    'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':
+        ref: 'v0.16.0'
+        commit: 'sha1-0a25abab892a91062ebf42260dbb2ce6277aa205'
+        owner_id: 46686594
+        repo_id: 1150447766
     'ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc':
         ref: 'v2.4.4'
         commit: 'sha1-2d1146689b8cda280b9bc96326124645441f03bc'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -53,28 +53,20 @@ jobs:
           fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Download verificado por digest — sem wrapper de terceiro: o binário oficial
-      # do CLI só executa se o SHA-256 conferir com o valor gravado abaixo
-      # (recomputado localmente e conferido contra o digest declarado pela API do
-      # GitHub em 17/08/2026). Troca de versão exige atualizar URL e digest juntos,
-      # por desenho. Inventário e fronteira de confiança em THIRDPARTY.md do
-      # repositório de governança.
+      # Action oficial da Linear, pinada ao commit assinado da v0.16.0. A versão
+      # v0.16.0 do CLI é selecionada explicitamente; o instalador oficial ainda
+      # baixa esse artefato sem verificação criptográfica, lacuna rastreada em
+      # linear/linear-release-action#59.
       #
       # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (digest divergente, indisponibilidade, segredo expirado) NUNCA pode
+      # falha (indisponibilidade, erro do CLI, segredo expirado) NUNCA pode
       # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
       # falha fica visível na anotação do passo; commits não sincronizados embarcam
       # na release seguinte.
-      - name: Create Linear release (CLI verificado por digest)
+      - name: Create Linear release with the official action
         id: linear_release
         continue-on-error: true
-        env:
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          CLI_URL: https://github.com/linear/linear-release/releases/download/v0.15.0/linear-release-linux-x64
-          CLI_SHA256: 06eddce3f0d306fcdfed634105a57b02695b5c4fb40c42eb56d13feced729c99
-        run: |
-          bin="$RUNNER_TEMP/linear-release"
-          curl -fsSL "$CLI_URL" -o "$bin"
-          echo "$CLI_SHA256  $bin" | sha256sum -c -
-          chmod +x "$bin"
-          "$bin" sync
+        uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          cli_version: v0.16.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,11 @@ npm run format:public:check
 
 Follow the workspace-root `AGENTS.md` directives of the private workspace that
 hosts this checkout (not versioned in this public repository). In
-particular: no self-review in cross-review gates, `ultrabrain` plus
-`cross-review-v2` before substantive closure, `cross-review-v1` only as fallback
-for v2, `main` as the deployment branch, and Commit & Sync only after final
-audit when requested.
+particular: no self-review in cross-review gates; use `ultrabrain` for every
+change and the single `cross-review` service for substantive work (simple
+mechanical changes, such as replacing an action without changing product
+behavior, are exempt); use `main` as the deployment branch; and Commit & Sync
+only after the final audit when requested.
 
 ## Registro de trabalho (GitHub Projects, Issues e Discussions)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Alterado
 
+- O writer pós-deploy da #461/MAISITE-9 troca o instalador customizado pela
+  `linear/linear-release-action` oficial v0.16.0, fixada pelo SHA assinado, sem
+  mudar o contrato best-effort nem o SHA implantado que origina a release. O CLI
+  é selecionado explicitamente como v0.16.0; a falta de verificação do digest no
+  instalador upstream continua rastreada em `linear/linear-release-action#59`.
 - Os PRs Dependabot #431 e #432 foram consolidados: CodeQL usa v4.37.7 e o
   Zizmor passa a usar diretamente a Action oficial v0.6.2 com CLI 1.29.0.
 - CodeQL, Dependency Review, OpenSSF Scorecard, Zizmor, GitHub Pages e os dois

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "format:public": "prettier --write \"**/index.html\"",
-    "format:public:check": "prettier --check \"**/index.html\""
+    "format:public:check": "prettier --check \"**/index.html\"",
+    "test:official-actions": "node --test scripts/official-actions-contract.test.mjs"
   },
   "devDependencies": {
     "prettier": "^3.9.6"

--- a/scripts/official-actions-contract.test.mjs
+++ b/scripts/official-actions-contract.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import test from "node:test";
+
+const CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1";
+const LINEAR_ACTION_SHA = "0a25abab892a91062ebf42260dbb2ce6277aa205";
+const WRANGLER_ACTION_SHA = "ebbaa1584979971c8614a24965b4405ff95890e0";
+
+const repositoryRoot = new URL("../", import.meta.url);
+const workflowDirectory = new URL(".github/workflows/", repositoryRoot);
+const linearReleaseSource = await readFile(
+  new URL("linear-release.yml", workflowDirectory),
+  "utf8",
+);
+const deploySource = await readFile(
+  new URL("deploy.yml", workflowDirectory),
+  "utf8",
+);
+const actionsLockSource = await readFile(
+  new URL("actions.lock", workflowDirectory),
+  "utf8",
+);
+const agentsGuide = await readFile(
+  new URL("AGENTS.md", repositoryRoot),
+  "utf8",
+);
+
+function occurrences(source, value) {
+  return source.split(value).length - 1;
+}
+
+function lockChildBlock(source, marker) {
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `lock block not found: ${marker.trim()}`);
+  const end = source.indexOf("\n    '", start + marker.length);
+  assert.notEqual(
+    end,
+    -1,
+    `lock block has no terminal boundary: ${marker.trim()}`,
+  );
+  return source.slice(start, end);
+}
+
+test("Linear Release remains downstream of the exact successful Deploy SHA", () => {
+  assert.match(
+    linearReleaseSource,
+    /workflow_run:[\s\S]*workflows:\s*\n\s*- Deploy\s*\n\s*types:\s*\n\s*- completed/u,
+  );
+  assert.match(
+    linearReleaseSource,
+    /github\.event\.workflow_run\.conclusion == 'success'[\s\S]*github\.event\.workflow_run\.head_branch == 'main'/u,
+  );
+  assert.match(
+    linearReleaseSource,
+    /group: linear-release-\$\{\{ github\.event\.workflow_run\.head_branch \}\}-\$\{\{ github\.event\.workflow_run\.conclusion \}\}/u,
+  );
+  assert.match(linearReleaseSource, /environment: linear-release/u);
+  assert.match(linearReleaseSource, /permissions:\s*\n\s*contents: read/u);
+  assert.match(
+    linearReleaseSource,
+    new RegExp(`uses: actions/checkout@${CHECKOUT_SHA}`, "u"),
+  );
+  assert.match(
+    linearReleaseSource,
+    /ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/u,
+  );
+  assert.match(linearReleaseSource, /fetch-depth: 0/u);
+  assert.match(linearReleaseSource, /persist-credentials: false/u);
+});
+
+test("Linear Release uses the signed official action and preserves best-effort", () => {
+  assert.equal(
+    occurrences(
+      linearReleaseSource,
+      `linear/linear-release-action@${LINEAR_ACTION_SHA}`,
+    ),
+    1,
+  );
+  assert.match(
+    linearReleaseSource,
+    /access_key: \$\{\{ secrets\.LINEAR_ACCESS_KEY \}\}/u,
+  );
+  assert.match(linearReleaseSource, /cli_version: v0\.16\.0/u);
+  assert.match(linearReleaseSource, /continue-on-error: true/u);
+  assert.doesNotMatch(
+    linearReleaseSource,
+    /linear-release-linux-x64|CLI_SHA256|curl -fsSL|sha256sum/u,
+  );
+});
+
+test("the official Wrangler action preserves both deploys and their order", async () => {
+  const wranglerAction = `cloudflare/wrangler-action@${WRANGLER_ACTION_SHA}`;
+  assert.equal(occurrences(deploySource, wranglerAction), 2);
+  assert.equal(occurrences(deploySource, 'wranglerVersion: "4.123.0"'), 2);
+
+  const worker = deploySource.indexOf("- name: Deploy Worker with Wrangler");
+  const frontend = deploySource.indexOf(
+    "- name: Deploy frontend with Wrangler",
+  );
+  assert.ok(worker >= 0 && frontend > worker);
+  assert.match(
+    deploySource.slice(worker, frontend),
+    /workingDirectory: mainsite-worker[\s\S]*command: deploy --strict/u,
+  );
+  assert.match(
+    deploySource.slice(frontend),
+    /workingDirectory: mainsite-frontend[\s\S]*command: pages deploy dist --project-name=mainsite-frontend --branch=main --commit-dirty=true/u,
+  );
+
+  const workflowSources = await Promise.all(
+    (await readdir(workflowDirectory))
+      .filter((name) => /\.ya?ml$/u.test(name))
+      .map((name) => readFile(new URL(name, workflowDirectory), "utf8")),
+  );
+  assert.doesNotMatch(
+    workflowSources.join("\n"),
+    /slackapi\/slack-github-action@|hooks\.slack\.com|slack\.com\/api\/chat\.postMessage|chat\.postMessage|SLACK_WEBHOOK|SLACK_BOT_TOKEN/u,
+  );
+});
+
+test("actions.lock and agent policy encode the same contract", () => {
+  const linearAction = `linear/linear-release-action@${LINEAR_ACTION_SHA}`;
+  assert.equal(
+    lockChildBlock(
+      actionsLockSource,
+      "    '.github/workflows/linear-release.yml':\n",
+    ),
+    [
+      "    '.github/workflows/linear-release.yml':",
+      `        - 'actions/checkout@${CHECKOUT_SHA}'`,
+      `        - '${linearAction}'`,
+    ].join("\n"),
+  );
+  assert.equal(
+    lockChildBlock(actionsLockSource, `    '${linearAction}':\n`),
+    [
+      `    '${linearAction}':`,
+      "        ref: 'v0.16.0'",
+      `        commit: 'sha1-${LINEAR_ACTION_SHA}'`,
+      "        owner_id: 46686594",
+      "        repo_id: 1150447766",
+    ].join("\n"),
+  );
+  assert.match(agentsGuide, /single `cross-review` service/u);
+  assert.doesNotMatch(agentsGuide, /cross-review-v[12]/u);
+});


### PR DESCRIPTION
## Resumo

- substitui somente o writer customizado pelo `linear/linear-release-action` oficial v0.16.0, pinado ao commit assinado completo;
- preserva `workflow_run` após `Deploy` bem-sucedido em `main`, o checkout do SHA efetivamente implantado, histórico completo, ambiente, permissões, concorrência e `continue-on-error: true`;
- mantém intactas as duas invocações já oficiais do Wrangler (Worker → frontend) e confirma que Slack não se aplica neste repositório;
- adiciona contrato versionado para a semântica e corrige a nomenclatura obsoleta de cross-review;
- registra a mudança no `CHANGELOG` e mantém explícita a lacuna upstream linear/linear-release-action#59.

## Validação local

- RED: 2/4 contratos passaram; falharam apenas action/lock/política ainda antigos.
- GREEN: 4/4 contratos passaram.
- Worker: audit sem vulnerabilidades, lint, Biome e 49/49 testes.
- Frontend: audit sem vulnerabilidades, lint, Biome, 28/28 testes e build.
- HTML público: Prettier verde.
- Zizmor nos workflows `linear-release.yml` e `deploy.yml`: zero findings.
- `gh actions-lock --no-fix`: válido; lock sem churn de pins não relacionados.
- Commit local assinado e verificação GitHub válida.

## Risco residual

A action é imutavelmente pinada; `cli_version` seleciona v0.16.0, mas o instalador upstream ainda baixa o binário sem verificação de digest. O acompanhamento permanece em https://github.com/linear/linear-release-action/issues/59.

Closes #461