### PR TITLE
docs(contacts): route conduct and support email (GIT-135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,7 +305,7 @@ Release só do worker; o frontend permanece em v03.23.05.
 ### Adicionado — Phase 3 sweep (flip readiness, puramente aditivo)
 
 - **`CONTRIBUTING.md`**: guia para issues + PRs cobrindo gates locais por sub-app (mainsite-frontend + mainsite-worker), wrangler dry-run, action pinning, versioning, regra de `public/_headers` intocável.
-- **`CODE_OF_CONDUCT.md`**: Contributor Covenant 3.0 com canal `lcv@lcv.dev`.
+- **`CODE_OF_CONDUCT.md`**: Contributor Covenant 3.0 com canal `***@lcv.dev`.
 - **`.github/CODEOWNERS`**: `* @example-beneficiary` como owner default.
 - **`.npmignore`**: baseline de ignore para tarball npm (segredo/secrets store/.wrangler/AI memory/internal docs como `NEXTJS_MIGRATION_PLAN.md`).
 - **`THIRDPARTY.md`**: inventário completo de dependências mainsite-frontend + mainsite-worker com licenças e origens.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Reports of violations can be sent privately to:
 
 **conductcode@lcv.dev**
 
-This is the same private channel used for security reports (see [SECURITY.md](./SECURITY.md)). Reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
+This channel is only for conduct reports. Security vulnerabilities must follow [SECURITY.md](./SECURITY.md) and be reported to **security@lcv.dev**. Conduct reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
 
 All reporters will have their identity kept confidential.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ This applies to:
 
 Reports of violations can be sent privately to:
 
-**lcv@lcv.dev**
+**conductcode@lcv.dev**
 
 This is the same private channel used for security reports (see [SECURITY.md](./SECURITY.md)). Reports will be acknowledged within 48 hours and handled per the Contributor Covenant 3.0 enforcement ladder.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ By contributing, you agree your contribution is licensed under [AGPL-3.0-or-late
 
 ## Code of Conduct
 
-By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `lcv@lcv.dev`.
+By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `chamados@lcv.dev`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ By contributing, you agree your contribution is licensed under [AGPL-3.0-or-late
 
 ## Code of Conduct
 
-By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). Violations to `chamados@lcv.dev`.
+By participating, you agree to follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (Contributor Covenant 3.0). General contribution and support requests go to `chamados@lcv.dev`; report conduct violations privately to `conductcode@lcv.dev`.
 
 ---
 


### PR DESCRIPTION
## Resumo

- Substitui o canal de conduta por conductcode@lcv.dev.
- Direciona chamados de contribuição para chamados@lcv.dev.
- Ofusca o endereço histórico no CHANGELOG.md como ***@lcv.dev.

## Verificação

- git diff --check: aprovado.
- Escopo: 3 arquivo(s) Markdown autorizado(s), 3 substituição(ões).
- lcv@lcv.dev restante nos alvos: 0.
- Suítes não executadas, conforme GIT-135 (mudança exclusivamente documental).

Refs LCV-Ideas-Software/github-operations#151
Linear: https://linear.app/lcv-ideas-software/issue/GIT-135/maintenance-padronizar-canais-de-conduta-e-chamados-na-frota