### PR TITLE
fix(ci): preserve Dependabot cooldown and release queue (MAISITE-13)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     cooldown:
       default-days: 7
       exclude:
-        - "*"
+        - "actions/*"
+        - "github/*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -17,19 +17,12 @@ on:
 # Política enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
 # workflow e grant mínimo declarado no job.
 permissions: {}
-# Agrupamento intencional: o CLI varre todos os commits desde a última release
-# (fetch-depth: 0). Se um run pendente for substituído por um mais novo, os
-# commits dele embarcam na release do run seguinte — nada se perde; releases
-# agrupam deploys em rajada por desenho, e o grupo evita corrida entre duas
-# criações de release simultâneas.
-# O grupo inclui a CONCLUSÃO do Deploy: o filtro do job (if) só age depois do
-# enfileiramento, então um run de Deploy falhado entraria no mesmo grupo e
-# poderia substituir na fila um run de sucesso pendente — deixando o SHA
-# publicado sem release até o próximo deploy. Com a conclusão na chave, runs de
-# falha (que o if pula) nunca deslocam runs de sucesso.
+# Cada Deploy bem-sucedido precisa gerar sua própria release. `queue: max`
+# preserva todos os runs pendentes do grupo, e a conclusão na chave mantém runs
+# falhados (que o job ignora) separados dos runs de sucesso.
 concurrency:
   group: linear-release-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.conclusion }}
-  cancel-in-progress: false
+  queue: max
 jobs:
   linear_release:
     name: Linear Release
@@ -58,14 +51,11 @@ jobs:
       # baixa esse artefato sem verificação criptográfica, lacuna rastreada em
       # linear/linear-release-action#59.
       #
-      # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (indisponibilidade, erro do CLI, segredo expirado) NUNCA pode
-      # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
-      # falha fica visível na anotação do passo; commits não sincronizados embarcam
-      # na release seguinte.
+      # A sincronização falha de forma visível: indisponibilidade, erro do CLI ou
+      # segredo expirado deixam o workflow vermelho, evitando perder
+      # silenciosamente a release do SHA publicado.
       - name: Create Linear release with the official action
         id: linear_release
-        continue-on-error: true
         uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 ### Alterado
 
 - O writer pós-deploy da #461/MAISITE-9 troca o instalador customizado pela
-  `linear/linear-release-action` oficial v0.16.0, fixada pelo SHA assinado, sem
-  mudar o contrato best-effort nem o SHA implantado que origina a release. O CLI
-  é selecionado explicitamente como v0.16.0; a falta de verificação do digest no
+  `linear/linear-release-action` oficial v0.16.0, fixada pelo SHA assinado,
+  preservando o SHA implantado que origina a release. A fila usa `queue: max`,
+  e falhas da action tornam o workflow vermelho. O CLI é selecionado
+  explicitamente como v0.16.0; a falta de verificação do digest no
   instalador upstream continua rastreada em `linear/linear-release-action#59`.
 - Os PRs Dependabot #431 e #432 foram consolidados: CodeQL usa v4.37.7 e o
   Zizmor passa a usar diretamente a Action oficial v0.6.2 com CLI 1.29.0.

--- a/scripts/official-actions-contract.test.mjs
+++ b/scripts/official-actions-contract.test.mjs
@@ -54,6 +54,8 @@ test("Linear Release remains downstream of the exact successful Deploy SHA", () 
     linearReleaseSource,
     /group: linear-release-\$\{\{ github\.event\.workflow_run\.head_branch \}\}-\$\{\{ github\.event\.workflow_run\.conclusion \}\}/u,
   );
+  assert.match(linearReleaseSource, /queue: max/u);
+  assert.doesNotMatch(linearReleaseSource, /cancel-in-progress:/u);
   assert.match(linearReleaseSource, /environment: linear-release/u);
   assert.match(linearReleaseSource, /permissions:\s*\n\s*contents: read/u);
   assert.match(
@@ -68,7 +70,7 @@ test("Linear Release remains downstream of the exact successful Deploy SHA", () 
   assert.match(linearReleaseSource, /persist-credentials: false/u);
 });
 
-test("Linear Release uses the signed official action and preserves best-effort", () => {
+test("Linear Release uses the signed official action and fails closed", () => {
   assert.equal(
     occurrences(
       linearReleaseSource,
@@ -81,7 +83,7 @@ test("Linear Release uses the signed official action and preserves best-effort",
     /access_key: \$\{\{ secrets\.LINEAR_ACCESS_KEY \}\}/u,
   );
   assert.match(linearReleaseSource, /cli_version: v0\.16\.0/u);
-  assert.match(linearReleaseSource, /continue-on-error: true/u);
+  assert.doesNotMatch(linearReleaseSource, /continue-on-error:\s*true/u);
   assert.doesNotMatch(
     linearReleaseSource,
     /linear-release-linux-x64|CLI_SHA256|curl -fsSL|sha256sum/u,


### PR DESCRIPTION
## Summary
- keep the seven-day Dependabot cooldown for third-party GitHub Actions
- exempt only official actions/* and github/* software
- queue every pending Linear Release run with queue: max
- fail visibly when the official Linear Release action fails
- preserve triggers, concurrency group, action pins, permissions, secrets, and actions.lock

## Validation
- YAML converted with yq and asserted with jq
- gh actions-lock --verify-local: valid
- Zizmor: no findings
- git diff --check: clean
- actions.lock: byte-identical
- commit: GPG signature verified

Closes #472

Linear: https://linear.app/lcv-ideas-software/issue/MAISITE-13
Refs LCV-Ideas-Software/github-operations#143

Official queue documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-queueing-multiple-pending-runs