### PR TITLE
fix(legal): align worker license metadata

### DIFF
--- a/mainsite-worker/package-lock.json
+++ b/mainsite-worker/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "mainsite-worker",
       "version": "2.7.0",
-      "license": "ISC",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@types/sanitize-html": "^2.16.1",
         "hono": "^4.13.3",

--- a/mainsite-worker/package.json
+++ b/mainsite-worker/package.json
@@ -15,7 +15,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "AGPL-3.0-or-later",
   "type": "module",
   "dependencies": {
     "@types/sanitize-html": "^2.16.1",


### PR DESCRIPTION
## Summary

- replace the incorrect `ISC` declaration in `mainsite-worker/package.json` with the repository's canonical `AGPL-3.0-or-later` SPDX identifier
- keep the derived root package entry in `mainsite-worker/package-lock.json` synchronized
- leave dependency licenses, versions, application behavior, and license text unchanged

## Root cause and evidence

The worker package metadata retained an `ISC` value that conflicts with the repository-level `LICENSE` and `THIRDPARTY.md`. The pre-fix assertion failed with `packageLicense=ISC` and `lockRootLicense=ISC`; the same assertion now reports `AGPL-3.0-or-later` for both.

Official references:

- npm package `license` metadata: https://docs.npmjs.com/cli/v11/configuring-npm/package-json/#license
- SPDX identifier: https://spdx.org/licenses/AGPL-3.0-or-later.html

## Validation

- [x] clean `npm ci` at root, Worker, and Frontend
- [x] `npm run format:public:check` (22 third-party tests; 51 direct dependency records verified)
- [x] Worker: `npm run lint`, `npm run biome`, `npm test` (10 files / 49 tests)
- [x] Frontend: `npm run lint`, `npm run biome`, `npm test` (5 files / 28 tests), `npm run build`
- [x] `git diff --check`
- [x] signed commit `c48c314704096f3ea4d4c14762fd9cbc775f8e7d`

Closes #501