### PR TITLE
fix(deps): bump linear-release-action to v0.17.1

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -18,7 +18,7 @@ workflows:
         - 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020'
     '.github/workflows/linear-release.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
-        - 'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205'
+        - 'linear/linear-release-action@3f31fcf14c110cc53579fcc3575a26d469c413b4'
     '.github/workflows/pages.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d'
@@ -90,9 +90,9 @@ dependencies:
         commit: 'sha1-cdf488f595d80d6e07e03d4674febd5ab45fa938'
         owner_id: 9919
         repo_id: 259445878
-    'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':
-        ref: 'v0.16.0'
-        commit: 'sha1-0a25abab892a91062ebf42260dbb2ce6277aa205'
+    'linear/linear-release-action@3f31fcf14c110cc53579fcc3575a26d469c413b4':
+        ref: 'v0.17.1'
+        commit: 'sha1-3f31fcf14c110cc53579fcc3575a26d469c413b4'
         owner_id: 46686594
         repo_id: 1150447766
     'ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc':

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -46,9 +46,10 @@ jobs:
           fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Action oficial da Linear, pinada ao commit assinado da v0.16.0. A versão
-      # v0.16.0 do CLI é selecionada explicitamente; o instalador oficial ainda
-      # baixa esse artefato sem verificação criptográfica, lacuna rastreada em
+      # Action oficial da Linear, pinada ao commit da release v0.17.1, com a
+      # versão do CLI selecionada explicitamente. Desde a v0.16.1 o instalador
+      # verifica o CLI baixado contra um checksum SHA-256 publicado antes de
+      # executá-lo, fechando a lacuna rastreada em
       # linear/linear-release-action#59.
       #
       # A sincronização falha de forma visível: indisponibilidade, erro do CLI ou
@@ -56,7 +57,7 @@ jobs:
       # silenciosamente a release do SHA publicado.
       - name: Create Linear release with the official action
         id: linear_release
-        uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
+        uses: linear/linear-release-action@3f31fcf14c110cc53579fcc3575a26d469c413b4 # v0.17.1
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
-          cli_version: v0.16.0
+          cli_version: v0.17.1

--- a/scripts/official-actions-contract.test.mjs
+++ b/scripts/official-actions-contract.test.mjs
@@ -3,7 +3,7 @@ import { readFile, readdir } from "node:fs/promises";
 import test from "node:test";
 
 const CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1";
-const LINEAR_ACTION_SHA = "0a25abab892a91062ebf42260dbb2ce6277aa205";
+const LINEAR_ACTION_SHA = "3f31fcf14c110cc53579fcc3575a26d469c413b4";
 const WRANGLER_ACTION_SHA = "ebbaa1584979971c8614a24965b4405ff95890e0";
 
 const repositoryRoot = new URL("../", import.meta.url);
@@ -82,7 +82,7 @@ test("Linear Release uses the signed official action and fails closed", () => {
     linearReleaseSource,
     /access_key: \$\{\{ secrets\.LINEAR_ACCESS_KEY \}\}/u,
   );
-  assert.match(linearReleaseSource, /cli_version: v0\.16\.0/u);
+  assert.match(linearReleaseSource, /cli_version: v0\.17\.1/u);
   assert.doesNotMatch(linearReleaseSource, /continue-on-error:\s*true/u);
   assert.doesNotMatch(
     linearReleaseSource,
@@ -137,7 +137,7 @@ test("actions.lock and agent policy encode the same contract", () => {
     lockChildBlock(actionsLockSource, `    '${linearAction}':\n`),
     [
       `    '${linearAction}':`,
-      "        ref: 'v0.16.0'",
+      "        ref: 'v0.17.1'",
       `        commit: 'sha1-${LINEAR_ACTION_SHA}'`,
       "        owner_id: 46686594",
       "        repo_id: 1150447766",


### PR DESCRIPTION
## O que muda

Atualiza a action oficial da Linear de **v0.16.0** para **v0.17.1** e sincroniza, na mesma pull request, todo registro deste repositório que nomeava o commit ou a versão antiga.

- `linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0` → `@3f31fcf14c110cc53579fcc3575a26d469c413b4 # v0.17.1`
- `cli_version: v0.16.0` → `cli_version: v0.17.1`
- `.github/workflows/actions.lock` regenerado pela ferramenta oficial
- onde existirem: `THIRDPARTY.md`, `README.md`, testes de invariante e scripts de contrato

O `CHANGELOG.md` não é tocado, por ser histórico.

## Por quê

A v0.16.0 é o commit que a própria Linear identifica na issue [linear/linear-release-action#59](https://github.com/linear/linear-release-action/issues/59) como aquele cujo instalador **baixa e executa o CLI sem verificar os bytes** — sem checksum, assinatura ou atestado. O job que executa essa action recebe o segredo `LINEAR_ACCESS_KEY`, então uma troca do artefato baixado significaria execução arbitrária no runner que detém o segredo.

A issue foi fechada como resolvida em 26/08/2026. Desde a v0.16.1 o instalador confere o artefato contra um checksum SHA-256 publicado antes de executá-lo.

Como a premissa do risco morreu, a prosa que o documentava como "exceção aceita" foi removida ou reescrita onde existia — deixá-la faria a documentação contradizer a configuração instalada.

## Verificação feita antes do commit

- **Pin preservado em SHA completo** com o comentário de versão. A regeneração do lockfile usou `--no-narrow --no-migrate-local-actions`; sem essas flags a ferramenta substitui o SHA pela tag, o que violaria o `sha_pinning_required` do repositório.
- **Lockfile coerente:** contém o SHA novo, não contém mais o antigo, e o campo `ref` registra `v0.17.1`.
- **Sem achados novos:** a contagem do `gh actions-lock --verify-local --no-fix` não aumentou em relação ao estado anterior à mudança.
- **Finais de linha intactos:** nenhum arquivo tocado mudou de LF para CRLF ou vice-versa.
- **Sem resíduo:** nenhuma menção ao SHA antigo sobrou em arquivo versionado, fora do histórico.
- **Suíte do próprio repositório executada localmente** e passando, onde existe.

Refs LCV-Ideas-Software/github-operations#216
Refs GIT-179

---
Claude Code (Claude Fable 5)
