### PR TITLE
ci(deploy): keep npm audit blocking on findings, warn when the advisory request fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,57 @@ jobs:
         working-directory: mainsite-worker
         run: npm ci --ignore-scripts --no-audit --no-fund
 
+      - name: Audit Worker dependencies
+        working-directory: mainsite-worker
+        shell: bash
+        env:
+          AUDIT_LABEL: mainsite-worker
+        run: |
+          # `npm audit --audit-level=high` with its failure classes kept apart: a
+          # report whose high or critical counts are above zero fails the step; a
+          # failed advisory request (npm's own message "audit endpoint returned an
+          # error": the registry advisory service down, unreachable or answering
+          # anything but a report) is a warning and the deploy continues on the
+          # native coverage (Dependabot alerts and security updates, Dependency
+          # Review, CodeQL); any npm error outside the advisory request fails the
+          # step. fetch-retries and fetch-timeout bound a hung request to about
+          # two minutes instead of npm's default of about fifteen.
+          set -u
+          out="$RUNNER_TEMP/npm-audit-$AUDIT_LABEL.json"
+          err="$RUNNER_TEMP/npm-audit-$AUDIT_LABEL.err"
+          status=0
+          npm audit --audit-level=high --json --fetch-retries=1 --fetch-timeout=60000 > "$out" 2> "$err" || status=$?
+          if node -e 'const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")); process.exit(Number.isInteger(r.auditReportVersion) ? 0 : 1)' "$out" 2> /dev/null; then
+            report_status=0
+            node -e 'const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")); const m = r.metadata.vulnerabilities; console.log(JSON.stringify(m)); for (const [name, v] of Object.entries(r.vulnerabilities)) if (v.severity === "high" || v.severity === "critical") console.log(v.severity + ": " + name + " " + v.range); process.exit(m.high + m.critical > 0 ? 3 : 0)' "$out" || report_status=$?
+            if [ "$report_status" -eq 3 ]; then
+              echo "::error title=npm audit ($AUDIT_LABEL)::the report lists high or critical vulnerabilities; see the step log"
+              exit 1
+            fi
+            if [ "$report_status" -ne 0 ]; then
+              echo "::error title=npm audit ($AUDIT_LABEL)::the audit report could not be read"
+              exit "$report_status"
+            fi
+            if [ "$status" -ne 0 ]; then
+              echo "::error title=npm audit ($AUDIT_LABEL)::npm audit exited $status although the report lists no high or critical vulnerability"
+              exit "$status"
+            fi
+            echo "npm audit ($AUDIT_LABEL): no high or critical vulnerability"
+            exit 0
+          fi
+          cat "$err"
+          if grep -q "audit endpoint returned an error" "$err"; then
+            echo "::warning title=npm audit ($AUDIT_LABEL)::the advisory request to the npm registry failed; the deploy continues on the native coverage (Dependabot alerts and security updates, Dependency Review, CodeQL)"
+            printf '### npm audit (%s)\n\nThe advisory request to the npm registry failed; the deploy continued without an audit result. Native coverage (Dependabot alerts and security updates, Dependency Review, CodeQL) still applies.\n\n' "$AUDIT_LABEL" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "::error title=npm audit ($AUDIT_LABEL)::npm audit failed before producing a report, for a reason outside the advisory request"
+          [ "$status" -ne 0 ] || status=1
+          exit "$status"
+
       - name: Validate Worker
         working-directory: mainsite-worker
         run: |
-          npm audit --audit-level=high
           npm run lint
           npm run biome
           npm test
@@ -52,10 +99,57 @@ jobs:
         working-directory: mainsite-frontend
         run: npm ci --ignore-scripts --no-audit --no-fund
 
+      - name: Audit frontend dependencies
+        working-directory: mainsite-frontend
+        shell: bash
+        env:
+          AUDIT_LABEL: mainsite-frontend
+        run: |
+          # `npm audit --audit-level=high` with its failure classes kept apart: a
+          # report whose high or critical counts are above zero fails the step; a
+          # failed advisory request (npm's own message "audit endpoint returned an
+          # error": the registry advisory service down, unreachable or answering
+          # anything but a report) is a warning and the deploy continues on the
+          # native coverage (Dependabot alerts and security updates, Dependency
+          # Review, CodeQL); any npm error outside the advisory request fails the
+          # step. fetch-retries and fetch-timeout bound a hung request to about
+          # two minutes instead of npm's default of about fifteen.
+          set -u
+          out="$RUNNER_TEMP/npm-audit-$AUDIT_LABEL.json"
+          err="$RUNNER_TEMP/npm-audit-$AUDIT_LABEL.err"
+          status=0
+          npm audit --audit-level=high --json --fetch-retries=1 --fetch-timeout=60000 > "$out" 2> "$err" || status=$?
+          if node -e 'const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")); process.exit(Number.isInteger(r.auditReportVersion) ? 0 : 1)' "$out" 2> /dev/null; then
+            report_status=0
+            node -e 'const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")); const m = r.metadata.vulnerabilities; console.log(JSON.stringify(m)); for (const [name, v] of Object.entries(r.vulnerabilities)) if (v.severity === "high" || v.severity === "critical") console.log(v.severity + ": " + name + " " + v.range); process.exit(m.high + m.critical > 0 ? 3 : 0)' "$out" || report_status=$?
+            if [ "$report_status" -eq 3 ]; then
+              echo "::error title=npm audit ($AUDIT_LABEL)::the report lists high or critical vulnerabilities; see the step log"
+              exit 1
+            fi
+            if [ "$report_status" -ne 0 ]; then
+              echo "::error title=npm audit ($AUDIT_LABEL)::the audit report could not be read"
+              exit "$report_status"
+            fi
+            if [ "$status" -ne 0 ]; then
+              echo "::error title=npm audit ($AUDIT_LABEL)::npm audit exited $status although the report lists no high or critical vulnerability"
+              exit "$status"
+            fi
+            echo "npm audit ($AUDIT_LABEL): no high or critical vulnerability"
+            exit 0
+          fi
+          cat "$err"
+          if grep -q "audit endpoint returned an error" "$err"; then
+            echo "::warning title=npm audit ($AUDIT_LABEL)::the advisory request to the npm registry failed; the deploy continues on the native coverage (Dependabot alerts and security updates, Dependency Review, CodeQL)"
+            printf '### npm audit (%s)\n\nThe advisory request to the npm registry failed; the deploy continued without an audit result. Native coverage (Dependabot alerts and security updates, Dependency Review, CodeQL) still applies.\n\n' "$AUDIT_LABEL" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "::error title=npm audit ($AUDIT_LABEL)::npm audit failed before producing a report, for a reason outside the advisory request"
+          [ "$status" -ne 0 ] || status=1
+          exit "$status"
+
       - name: Validate frontend
         working-directory: mainsite-frontend
         run: |
-          npm audit --audit-level=high
           npm run lint
           npm run biome
           npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — MainSite App
 
+## [Unreleased]
+
+### Alterado
+
+- **`npm audit` do `Deploy` distingue vulnerabilidade de requisição de advisories falha.** O
+  passo de auditoria de cada pacote continua reprovando o deploy quando o relatório traz
+  vulnerabilidade alta ou crítica; quando a requisição de advisories ao registro do npm falha
+  (mensagem do próprio npm, "audit endpoint returned an error": serviço fora, inalcançável ou
+  respondendo qualquer coisa que não um relatório), registra um aviso e um resumo no job e o
+  deploy segue sobre a cobertura nativa (alertas e atualizações de segurança do Dependabot,
+  Dependency Review, CodeQL); qualquer erro do npm fora dessa requisição reprova. A espera por
+  uma requisição travada cai de cerca de quinze minutos para cerca de dois (`fetch-retries` 1,
+  `fetch-timeout` 60 s). Motivo: em 03/09 o serviço ficou horas sem responder e nenhum deploy
+  saía, hotfix incluído (MAISITE-20 / #531).
+
 ## [v03.25.00 / v02.22.00] - 2026-09-03
 
 Release só do frontend; o worker permanece em v02.22.00, em produção desde o `Deploy` de

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ npm test
 npx wrangler deploy --dry-run --strict
 ```
 
-All gates must be GREEN. The `CI` workflow re-runs them on every pull request to `main`; the `Deploy` workflow re-runs them on every push to `main`, adding `npm audit` and replacing the dry run with the real `wrangler deploy --strict`.
+All gates must be GREEN. The `CI` workflow re-runs them on every pull request to `main`; the `Deploy` workflow re-runs them on every push to `main`, adding `npm audit` (a report with a high or critical finding stops the deploy; a failed advisory request to the npm registry only warns) and replacing the dry run with the real `wrangler deploy --strict`.
 
 ### PR description
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ cd ..
 
 This repo's [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) runs on every push to `main`:
 
-1. `npm ci` + `npm audit --audit-level=high` for both sub-apps.
+1. `npm ci` + `npm audit --audit-level=high` for both sub-apps (a report with a high or critical finding stops the deploy; when the advisory request to the npm registry fails, the step warns and the deploy continues on the native coverage; any other npm error stops the deploy).
 2. `lint`, Biome and tests for both, plus the frontend build.
 3. The official Cloudflare Wrangler Action deploys the Worker and the Pages frontend with the versioned D1 binding.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,10 @@ Out of scope: social engineering, physical attacks, denial-of-service testing wi
   for `mainsite-worker`; lint, Biome, tests and build for `mainsite-frontend`), Dependency Review,
   zizmor and the Pages build; `npm audit` runs only on pushes to `main`, inside the `Deploy`
   workflow, together with lint, Biome and tests of both packages, the frontend build and the two
-  Wrangler deployments. The repository ruleset `main: required
+  Wrangler deployments. A report with a high or critical finding stops the deploy; when the
+  advisory request to the npm registry fails, the audit step records a warning and the deploy
+  continues on the native coverage (Dependabot alerts and security updates, Dependency Review,
+  CodeQL); any other npm error stops the deploy. The repository ruleset `main: required
   checks` requires `CI`, `Build Pages artifact`, `Dependency Review` and `Run zizmor` before any
   merge into `main`.
 - This repository handles its own Dependabot pull requests with the repository-local workflow


### PR DESCRIPTION
> **Autoria:** pull request produzido por **Claude Code (Claude Fable 5.1)** em 03/09/2026, por decisão do operador às 21:29 ("Sobre o Deploy, opção 2"), depois de consulta à documentação do npm e medição do comportamento do `npm audit` 12.0.2.

## Summary

- `npm audit` posts the package tree to `registry.npmjs.org/-/npm/v1/security/advisories/bulk`; npm 12 removed the fallback to the retired quick-audit endpoint and offers no setting that tolerates the service being unavailable (`fetch-timeout` only bounds each attempt). On 03/09/2026 the advisory service returned 503 or nothing for hours while the npm status page stayed "operational", and every `Deploy` of `main` failed at the audit step, reruns included.
- The validation steps stop calling `npm audit --audit-level=high` directly. A dedicated **Audit ... dependencies** step per package runs `npm audit --audit-level=high --json` and keeps three cases apart:
  1. a real report (`auditReportVersion` present) whose high or critical counts are above zero: the step fails, printing the counts and the high/critical entries (the decision reads the report's counts, not npm's exit code; a non-zero exit with a report showing no high or critical finding also fails, fail-closed);
  2. a failed advisory request: npm prints no report and its own message `audit endpoint returned an error` on stderr (service down, unreachable, or answering anything but a report); the step records a `::warning` annotation and a job-summary note and exits 0, so the deploy continues on the native coverage (Dependabot alerts and security updates, Dependency Review, CodeQL);
  3. any npm error outside the advisory request (no report, different message, for example `ENOLOCK`): the step fails.
- `--fetch-retries=1 --fetch-timeout=60000` bound a hung request to about two minutes per package instead of npm's default of about fifteen (two retries of five minutes plus backoff), which would otherwise consume the job timeout before the tolerant path runs.
- Behaviour measured on npm 12.0.2 before writing (endpoint failure, unreachable registry, missing lockfile) and the embedded script exercised with stubbed `npm` outputs under `bash --noprofile --norc -eo pipefail`, the flags GitHub uses for `shell: bash`; the table is in the first comment. The real command with the new flags, run while the service was down, returned the message path in about two minutes.
- Documentation aligned (SECURITY.md, CHANGELOG `Unreleased`, and where they exist the README section that lists the Deploy steps and the CONTRIBUTING sentence about the Deploy gates). No application code changes; internal versions unchanged.

## Validation

- [x] Relevant local checks were run or the change is documentation/configuration only: zizmor on `deploy.yml` (no findings), actionlint with shellcheck (clean), `bash -n` on the embedded blocks, YAML parse, behavioural cases, `git diff --check`, Prettier where the repository governs it.
- [x] GitHub Actions changes use least-privilege permissions and immutable action SHAs: no permission or action pin changed; the new steps contain no `${{ }}` expression inside `run`.
- [x] Dependabot automation remains non-blocking for routine patch/minor updates: `CI` is untouched; only the push-to-`main` `Deploy` changes.

## Security Notes

- [x] No secrets, credentials, tokens, or private infrastructure details were added.
- [x] New deployment or cloud access uses short-lived credentials or OIDC where practical: no new access.

Closes #531. Fixes MAISITE-20.

Opened by Claude on behalf of the operator.

