### PR TITLE
fix(legal): deliver native bundled dependency notices (MAISITE-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Alterado
 
+- O frontend passa a publicar os textos de licença das dependências incorporadas usando
+  `build.license` nativo do Vite, em `/legal/DEPENDENCY-LICENSES.md`, com referência nos
+  bundles e link na página de licenças. O Workbox, gerado separadamente, recebe uma cópia
+  integral e inalterada de sua licença MIT em `/legal/WORKBOX-LICENSE.txt`. Sem novo
+  verificador, gerador próprio, dependência ou mudança de configuração do GitHub.
+
 - **`npm audit` do `Deploy` distingue vulnerabilidade de requisição de advisories falha.** O
   passo de auditoria de cada pacote continua reprovando o deploy quando o relatório traz
   vulnerabilidade alta ou crítica; quando a requisição de advisories ao registro do npm falha

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -12,6 +12,13 @@ which provides the SBOM on request, rather than being duplicated here.
 The repository itself remains licensed under `AGPL-3.0-or-later`. Third-party components
 remain subject to their own terms, and none is modified or vendored by this repository.
 
+The frontend build also publishes the bundled dependencies' full license texts at
+`/legal/DEPENDENCY-LICENSES.md`, using [Vite's native license output](https://vite.dev/config/build-options#build-license).
+The legal page links to that build-specific report. Workbox is bundled separately by
+`generateSW`; `/legal/WORKBOX-LICENSE.txt` preserves the upstream MIT text shared by the
+Workbox 7.4.1 runtime packages, copied unchanged through Vite's public directory. Review
+that notice against the upstream package license when upgrading Workbox.
+
 | Pacote            | Componente                       | Relação     | Licença                 | Fonte                                                                                 |
 | ----------------- | -------------------------------- | ----------- | ----------------------- | ------------------------------------------------------------------------------------- |
 | mainsite-frontend | `@biomejs/biome`                 | development | MIT OR Apache-2.0       | https://github.com/biomejs/biome (`packages/@biomejs/biome`)                          |

--- a/mainsite-frontend/public/legal/THIRDPARTY.md
+++ b/mainsite-frontend/public/legal/THIRDPARTY.md
@@ -12,6 +12,13 @@ which provides the SBOM on request, rather than being duplicated here.
 The repository itself remains licensed under `AGPL-3.0-or-later`. Third-party components
 remain subject to their own terms, and none is modified or vendored by this repository.
 
+The frontend build also publishes the bundled dependencies' full license texts at
+`/legal/DEPENDENCY-LICENSES.md`, using [Vite's native license output](https://vite.dev/config/build-options#build-license).
+The legal page links to that build-specific report. Workbox is bundled separately by
+`generateSW`; `/legal/WORKBOX-LICENSE.txt` preserves the upstream MIT text shared by the
+Workbox 7.4.1 runtime packages, copied unchanged through Vite's public directory. Review
+that notice against the upstream package license when upgrading Workbox.
+
 | Pacote            | Componente                       | Relação     | Licença                 | Fonte                                                                                 |
 | ----------------- | -------------------------------- | ----------- | ----------------------- | ------------------------------------------------------------------------------------- |
 | mainsite-frontend | `@biomejs/biome`                 | development | MIT OR Apache-2.0       | https://github.com/biomejs/biome (`packages/@biomejs/biome`)                          |

--- a/mainsite-frontend/public/legal/WORKBOX-LICENSE.txt
+++ b/mainsite-frontend/public/legal/WORKBOX-LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright 2018 Google LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/mainsite-frontend/src/modules/compliance/LicencasModule.tsx
+++ b/mainsite-frontend/src/modules/compliance/LicencasModule.tsx
@@ -114,8 +114,13 @@ export function LicencasModule() {
         Conformidade e Licenças (Open Source Compliance)
       </h1>
       <p style={{ color: '#5f6368', marginBottom: '32px' }}>
-        Este sistema opera sob a GNU Affero General Public License v3 (AGPLv3), com avisos e componentes de terceiros
-        sob Apache License 2.0 devidamente documentados em NOTICE e THIRDPARTY.md.
+        Este sistema opera sob a GNU Affero General Public License v3 (AGPLv3). Os componentes de terceiros preservam
+        suas próprias licenças e avisos de autoria.
+      </p>
+      <p style={paragraphStyle}>
+        Consulte os <a href={`${LEGAL_PUBLIC_BASE}DEPENDENCY-LICENSES.md`}>textos das licenças das dependências</a>{' '}
+        distribuídas neste site e a <a href={`${LEGAL_PUBLIC_BASE}WORKBOX-LICENSE.txt`}>licença do Workbox</a>, usado
+        pelo serviço de navegação offline.
       </p>
 
       <section style={sectionStyle}>

--- a/mainsite-frontend/vite.config.ts
+++ b/mainsite-frontend/vite.config.ts
@@ -115,8 +115,10 @@ export default defineConfig({
   build: {
     target: 'esnext',
     cssCodeSplit: false,
+    license: { fileName: 'legal/DEPENDENCY-LICENSES.md' },
     rollupOptions: {
       output: {
+        postBanner: '/*! Bundled dependency licenses: /legal/DEPENDENCY-LICENSES.md */',
         manualChunks(id): string | undefined {
           if (id.includes('node_modules')) {
             if (id.includes('lucide-react')) return 'vendor-icons';


### PR DESCRIPTION
## Summary

Deliver dependency license texts using native Vite build.license. Link the generated public report and the unchanged Workbox MIT notice from the legal page, and correct the blanket Apache license wording.

Fixes #533
Linear: https://linear.app/lcv-ideas-software/issue/MAISITE-21
Audit: GIT-199 / GIT-200.

## Validation

- Frontend lint, Biome, 28 tests, TypeScript and production build passed.
- Worker lint, Biome, 49 tests and strict Wrangler deployment dry-run passed.
- Native generated report contains 8 bundled package entries with full LICENSE texts; 13/13 JS chunks reference it.
- Published Workbox text matches the 16 installed Workbox package licenses (SHA-256 aee9670e09b75ca8a2a1fe62d545ae38a6797970caf0335628e3a4dd15bc9b6c).
- Mirrored THIRDPARTY documents match; git diff --check and SSH signature verification passed.
- Actual tracked configuration tested with npm run build -- --config vite.config.ts; pre-existing ignored local JS config was preserved.

## Boundaries

No custom scanner/generator, controller, workflow, GitHub setting, dependency or lockfile changes. No version bump is required: main pushes trigger Deploy and successful Deploy triggers Linear Release. Production delivery remains to be verified after normal PR admission.

Official reference: https://vite.dev/config/build-options#build-license