### PR TITLE
docs: use native Wrangler bundling in fork deploy guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Alterado
 
+- Corrigido o guia de fork para usar o empacotamento nativo de `wrangler deploy` no Worker,
+  removendo a chamada a um script `build` que esse pacote não possui. O build do frontend
+  permanece; nenhuma configuração ou implementação foi alterada (GIT-202/GIT-203).
+
 - O frontend passa a publicar os textos de licença das dependências incorporadas usando
   `build.license` nativo do Vite, em `/legal/DEPENDENCY-LICENSES.md`, com referência nos
   bundles e link na página de licenças. O Workbox, gerado separadamente, recebe uma cópia

--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ Set the non-secret `VERTEX_PROJECT` Wrangler variable to your Google Cloud proje
 
 The Turnstile site key is public, but Vite still needs it at build time. Replace `your-public-site-key` below with the site key created for your fork.
 
+Wrangler bundles the Worker during `deploy`; the Worker package has no separate `build` script.
+
 ```bash
 cd mainsite-worker
-npm run build
 npx wrangler deploy
 cd ..
 


### PR DESCRIPTION
## Summary

Correct the fork deployment instructions: remove npm run build from mainsite-worker, which has no build script. Wrangler bundles the Worker during deploy. The frontend Vite build remains unchanged.

## Evidence and verification

- Compared the README with mainsite-worker/package.json and the existing successful native Wrangler deployment workflow.
- Official documentation: https://developers.cloudflare.com/workers/wrangler/bundling/
- git diff --check passed; README and CHANGELOG are the only changed files.
- Normal repository CI remains required. No deployment, credential, runtime code, dependency or GitHub setting changed.
- SSH-signed commit; signing configuration unchanged.

Audit: https://linear.app/lcv-ideas-software/issue/GIT-202 and https://linear.app/lcv-ideas-software/issue/GIT-203.
This PR does not close either audit issue.