### PR TITLE
chore: update official security action pins (LCV-178)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: mainsite-worker
-          wranglerVersion: "4.125.0"
+          wranglerVersion: "4.127.1"
           command: deploy --strict
 
       - name: Deploy frontend with Wrangler
@@ -174,5 +174,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: mainsite-frontend
-          wranglerVersion: "4.125.0"
+          wranglerVersion: "4.127.1"
           command: pages deploy dist --project-name=mainsite-frontend --branch=main --commit-dirty=true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,6 @@ jobs:
           retention-days: 5
 
       - name: Upload Scorecard results to code scanning
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,4 +33,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Alterado
 
+- Atualizados os pins oficiais de CodeQL para 4.38.0 e zizmor-action para 0.6.4.
+  Os dois inputs do deploy usam o Wrangler 4.127.1 já fixado nos lockfiles.
+
 - Preservado o aviso MIT integral do template oficial create-vite para
   `mainsite-frontend/public/icons.svg` em `THIRDPARTY.md` e na cópia publicada
   em `/legal/THIRDPARTY.md`. O asset estático é copiado pelo Vite fora do grafo


### PR DESCRIPTION
Os workflows ainda usavam referências anteriores às releases oficiais e aos lockfiles. Atualiza CodeQL para 4.38.0 e zizmor-action para 0.6.4 pelos SHAs completos verificados, e alinha os dois inputs de deploy ao Wrangler 4.127.1 já fixado nos lockfiles.

Validação local: gates completos dos pacotes worker e frontend, ambas as auditorias exigidas pelo deploy, Actionlint e Zizmor aprovados; reprodução das seis divergências passou para zero. Manifestos e lockfiles preservados. A validação local usou Node 26; a CI nativa usa Node 24.

Acompanhamento: [LCV-178](https://linear.app/lcv-ideas-software/issue/LCV-178).
