### PR TITLE
Run Dependabot daily at 05h and group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Sao_Paulo"
+      interval: "cron"
+      cronjob: "0 5 * * *"
+      timezone: "Etc/GMT+3"
     cooldown:
       default-days: 7
       exclude:
@@ -20,6 +19,10 @@ updates:
       include: "scope"
     open-pull-requests-limit: 10
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       minor-e-patch:
         applies-to: version-updates
         patterns:
@@ -31,10 +34,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/mainsite-frontend"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Sao_Paulo"
+      interval: "cron"
+      cronjob: "0 5 * * *"
+      timezone: "Etc/GMT+3"
     cooldown:
       default-days: 7
     rebase-strategy: auto
@@ -51,6 +53,10 @@ updates:
           - ">=6.1.0"
     open-pull-requests-limit: 10
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       minor-e-patch:
         applies-to: version-updates
         patterns:
@@ -62,10 +68,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/mainsite-worker"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Sao_Paulo"
+      interval: "cron"
+      cronjob: "0 5 * * *"
+      timezone: "Etc/GMT+3"
     cooldown:
       default-days: 7
     rebase-strategy: auto
@@ -82,6 +87,10 @@ updates:
           - ">=6.1.0"
     open-pull-requests-limit: 10
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       minor-e-patch:
         applies-to: version-updates
         patterns:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,24 @@ In scope: application code, Workers/Pages functions, package publication, GitHub
 
 Out of scope: social engineering, physical attacks, denial-of-service testing without prior written authorization, spam, automated noisy scanning, and reports that rely only on outdated browser or dependency versions without a concrete vulnerable path in this repository.
 
+## Dependency updates
+
+Dependabot checks all configured ecosystems every day, including weekends, at
+05:00 (UTC-03:00), using the native `cron` schedule and `Etc/GMT+3`. GitHub may
+start the jobs later when its update queue is busy. Version updates retain the
+seven-day cooldown and existing groups; official `actions/*` and `github/*`
+updates are excluded from that cooldown.
+
+Security updates run independently of this schedule and cooldown. Each configured
+ecosystem and directory has its own security group, separate from version updates.
+A failing update can delay its security group; diagnose the failure before
+adjusting the native group configuration or recreating a pull request. Existing
+version ignores also constrain security fixes, so review them when upstream
+compatibility changes. Native auto-merge remains subject to every required check.
+
+See the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
+and [security update documentation](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates).
+
 ## Automation and credentials
 
 - Pull requests against `main` run the `CI` workflow (lint, Biome, tests and a strict Wrangler dry run


### PR DESCRIPTION
Dependabot currently checks GitHub Actions and both npm packages weekly at 06:00. Schedule them every day, including weekends, at 05:00 (UTC-03:00) with GitHub's native cron configuration, and add separate security-update groups for each ecosystem/directory.

Preserve existing version groups, cooldowns and compatibility restrictions. Document security update timing, the effect of ignore rules, and the possibility that one failing update delays its security group.

Validation: YAML parsed and schedules/security groups verified; `git diff --check` passed. Frontend lint, Biome, 28 tests and production build passed. Worker lint, Biome, 49 tests and strict Wrangler deployment dry run passed. The independent configuration review and required checks must be confirmed at this PR's exact head before merge.

Closes #542. Linear: [MAISITE-23](https://linear.app/lcv-ideas-software/issue/MAISITE-23).
