### PR TITLE
fix(dependabot): coordinate Vitest peer updates [MAISITE-23]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,11 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       minor-e-patch:
         applies-to: version-updates
         patterns:
@@ -91,6 +96,11 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       minor-e-patch:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
Separate Vitest major updates fail npm CI because `@vitest/coverage-v8` and `@vitest/ui` require the matching `vitest` version. The current split updates reproduce ERESOLVE in PRs #545, #546, #548, #549 and #550.

Add a native version-update group for `vitest` and `@vitest/*` in each npm directory, before the general minor/patch group. The coordinated group includes major updates and retains all existing schedules, cooldowns, security groups and required checks.

Validation: parsed YAML comparison confirms only the two intended groups changed; lint/Biome, 28 frontend tests, 49 Worker tests, production build and strict Wrangler dry run passed. Exact-head repository checks and native update jobs remain required.

Closes #542.
Fixes MAISITE-23.
