### PR TITLE
ci: alinhar Wrangler do deploy aos lockfiles (MAISITE-25)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: mainsite-worker
-          wranglerVersion: "4.127.1"
+          wranglerVersion: "4.129.0"
           command: deploy --strict
 
       - name: Deploy frontend with Wrangler
@@ -174,5 +174,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
           workingDirectory: mainsite-frontend
-          wranglerVersion: "4.127.1"
+          wranglerVersion: "4.129.0"
           command: pages deploy dist --project-name=mainsite-frontend --branch=main --commit-dirty=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Alterado
 
 - Atualizados os pins oficiais de CodeQL para 4.38.0 e zizmor-action para 0.6.4.
-  Os dois inputs do deploy usam o Wrangler 4.127.1 já fixado nos lockfiles.
+  Os dois inputs do deploy usam o Wrangler 4.129.0 já fixado nos lockfiles.
 
 - Preservado o aviso MIT integral do template oficial create-vite para
   `mainsite-frontend/public/icons.svg` em `THIRDPARTY.md` e na cópia publicada


### PR DESCRIPTION
## Summary

Alinha os dois inputs `wranglerVersion` do Deploy a `4.129.0`, versão já fixada nos manifestos e lockfiles de `mainsite-worker` e `mainsite-frontend`, e corrige a mesma referência atual em `Unreleased`.

Closes #556. Rastreio: [MAISITE-25](https://linear.app/lcv-ideas-software/issue/MAISITE-25), identificado na auditoria [LCV-181](https://linear.app/lcv-ideas-software/issue/LCV-181).

## Validation

- [x] Reprodução antes/depois confirma o alinhamento dos dois inputs com manifestos e lockfiles.
- [x] Após `npm ci` nos dois pacotes: lint, Biome e testes (77 aprovados: 49 Worker + 28 frontend), build do frontend e `wrangler deploy --dry-run --strict` do Worker.
- [x] GitHub Actions preserva permissões existentes e os mesmos SHAs imutáveis.
- [x] Automação Dependabot preservada.

## Security Notes

- [x] Nenhum segredo, credencial ou detalhe privado de infraestrutura foi acrescentado.
- [x] Nenhum novo acesso à nuvem; o deploy automático existente permanece sujeito aos mesmos controles.
